### PR TITLE
Extend browser object

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,12 @@ webdriverioWithSync.multiremote = function (options) {
       _mainRemoteWrapper.instances.push(wrapper);
     }
   });
-  _mainRemoteWrapper.init();
+
+  var _returnOptions = _mainRemoteWrapper.init();
+  _mainRemoteWrapper.instances.forEach(function(browser, index) {
+    _mainRemoteWrapper.instances[index].desiredCapabilities = _returnOptions['browser' + index].value;
+    _mainRemoteWrapper.instances[index].options = options['browser' + index];
+  });
 
   return _mainRemoteWrapper;
 };
@@ -58,7 +63,13 @@ webdriverioWithSync.remote = function (options) {
 
   webdriverioWithSync.wrapAsyncBrowser(wws.remote, options);
 
-  return _.first(wws._wrappers);
+  var _mainRemoteWrapper = _.first(wws._wrappers);
+  var _returnOptions = _mainRemoteWrapper.initSync();
+
+  _mainRemoteWrapper.desiredCapabilities = _returnOptions.value;
+  _mainRemoteWrapper.options = options;
+
+  return _mainRemoteWrapper;
 };
 
 webdriverioWithSync.wrapAsyncBrowser = function(remote, options) {

--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ webdriverioWithSync.multiremote = function (options) {
 
   var _returnOptions = _mainRemoteWrapper.init();
   _mainRemoteWrapper.instances.forEach(function(browser, index) {
-    _mainRemoteWrapper.instances[index].desiredCapabilities = _returnOptions['browser' + index].value;
-    _mainRemoteWrapper.instances[index].options = options['browser' + index];
+    browser.desiredCapabilities = _returnOptions['browser' + index].value;
+    browser.options = options['browser' + index];
   });
 
   return _mainRemoteWrapper;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xolvio-sync-webdriverio",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "A sync version of WebdriverIO powered by Fibers",
   "keywords": [
     "webdriverio",


### PR DESCRIPTION
Since this won't work with a current version of chimp I bumbed the major version, and will use that in the new release of chimp. 
